### PR TITLE
Patch script on romb page to work correctly in italian

### DIFF
--- a/DISPOSITIVO_COMUNICAZIONE/romb/index.html
+++ b/DISPOSITIVO_COMUNICAZIONE/romb/index.html
@@ -11,6 +11,7 @@
     <link href="data:image/x-icon;base64,AAABAAEAEBAQAAAAAAAoAQAAFgAAACgAAAAQAAAAIAAAAAEABAAAAAAAgAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAsC8qAP+EAACzh1cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAACAAAAAAAAACAAAAAAAAEiAAAAADAAAiAAAAAAMzAiAAAAAAAAMzAAAAAAAAAiMzMAAAAAAAADAzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA" rel="icon" type="image/x-icon">
     <link rel="stylesheet" href="https://deltarune.com/_bridgetown/static/index.5WMRXJME.css" />
     <script src="https://deltarune.com/_bridgetown/static/index.IXDCFVRG.js" defer></script>
+    <script src="./patch_it.js" defer></script>
     
   </head>
   <body class="unknown  bg-black ">

--- a/DISPOSITIVO_COMUNICAZIONE/romb/patch_it.js
+++ b/DISPOSITIVO_COMUNICAZIONE/romb/patch_it.js
@@ -1,0 +1,36 @@
+// A series of monkey patches to make the interactive script work with our website, and translate some strings
+// Figured out by reverse engineering the frameworks the page uses (Stimulus and Howl) using the Firefox debugger.
+
+var controller = window.Stimulus.controllers[0];
+controller.locale["it"] = {
+    rumble: "Non potrai mai sconfiggerci! Che la sfida abbia inizio!"
+};
+controller.localeValue = "it";
+// Redirect audio links to point upstream
+controller.slam = new Howl({
+    src: [
+        'https://deltarune.com/assets/audio/slam.ogg',
+        'https://deltarune.com/assets/audio/slam.mp3'
+    ],
+    volume: 0.5
+});
+controller.ma = new Howl({
+    src: [
+        'https://deltarune.com/assets/audio/ma.ogg',
+        'https://deltarune.com/assets/audio/ma.mp3'
+    ],
+    volume: 0.5
+});
+controller.click = function () {
+    this.clickedValue == !1 &&
+        (
+            this.clickedValue = !0,
+            this.squareTarget.classList.add('animate-fly-off'),
+            this.squareTarget.classList.remove('cursor-pointer'),
+            this.ma.play(),
+            document.title = this.locale[this.localeValue].rumble,
+            setTimeout(() => {
+                window.location.href = '../capitolo3/index.html'
+            }, 3000)
+        )
+}


### PR DESCRIPTION
Minimum patch for making the script work with our website, which:
- Redirects links for assets to point to the original site
- Redirects link to '/chapter3' to point to './capitolo3'
- Translates window title to Italian